### PR TITLE
Reconcile README.rst with Component Files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,11 +94,11 @@ Next, create a Development virtual environment with Python 3 installed::
 
 where you might need to change it with your python path.
 
-Go to the virtual enviornment folder with::
+Go to the virtual environment folder with::
 
     $ cd $VIRTUAL_ENV/bin
 
-and edit the postactivate file.:
+and edit the postactivate file::
 
     $ vi postactivate
 
@@ -201,7 +201,7 @@ Once the translation is done, compile your messages with::
 Tests
 *****
 
-If you changed the default languages (English and Catalan), you need to update your Tests to make sure the translation works correclty. Open the file *functional_tests/test_all_users.py*:
+If you changed the default languages (English and Catalan), you need to update your Tests to make sure the translation works correctly. Open the file *functional_tests/test_all_users.py*:
 
 - in **test_internationalization**, update your languages with the translation of title text, here "Welcome to TaskBuster!"
 - in **test_localization**, update your languages.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,8 @@ This is an awesome **Django Project Boilerplate**!!
 With this code you can start a *complex* Django Project 
 very quickly, with just a few steps!
 
+Updated for Django 1.8 and Python 3!
+
 Some of the TaskBuster Django Project Boilerplate functionalities are:
 
 - **different virtual environments** for developing, testing and production

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -46,6 +46,9 @@ the name in a few places:
  - *taskbuster_project/taskbuster* **folder** (your project name)
  - virtual environment names: **tb_dev** and **tb_test** (name them whatever you want)
  - in virtual environments **postactivate** files (see section below), you have to change **taskbuster.settings.development** for your **projectname.settings.development**. Same works for the testing environment.
+ - in the **TaskBuster.sublime-project** and **TaskBuster.sublime-workspace** files. You should open the TaskBuster.sublime-project with Sublime Text and save it with another name.
+ - in *taskbuster_project/taskbuster* edit the file **wsgi.py** and change **"taskbuster.settings"** accordingly.
+ - in *taskbuster_project/taskbuster/settings* edit the **base.py** file and change the declarations of **ROOT_URLCONF** and **WSGI_APPLICATION**
 
 
 Virtual environments and Settings Files
@@ -103,6 +106,15 @@ Next, install the packages in each environment::
     $ pip install -r requirements/development.txt
     $ workon tb_test
     $ pip install -r requirements/testing.txt
+
+Next, apply the basic migrations::
+
+    $ python manage.py validate
+    $ python manage.py migrate
+
+And check that everything works by starting the server::
+
+    $ python manage.py runserver
 
 
 
@@ -173,7 +185,7 @@ Once the translation is done, compile your messages with::
 Tests
 *****
 
-We need to update the languages in our Tests to make sure the translation works correctly. Open the file *functional_tests/test_all_users.py*:
+If you changed the default languages (English and Catalan), you need to update your Tests to make sure the translation works correclty. Open the file *functional_tests/test_all_users.py*:
 
 - in **test_internationalization**, update your languages with the translation of title text, here "Welcome to TaskBuster!"
 - in **test_localization**, update your languages.


### PR DESCRIPTION
I Noticed some divergent changes between README.rst vs
docs/index.rst and docs/quick_start.rst. Accordingly I went through
the file histories, and made sure that changes to README.rst
made it to index.rst or quick_start.rst and vice versa.

for reference, the changes in this commit are based on those
in the following commits:

9ff76d7501e7c1d03b2cbb077203f997dc2bcd0c
cbd171088ac19d1ed4b12af12d13c5af58e20790
c0e977babd59f83e0b128b7e6afc78ce73330f69

Licensing Note: this is a strict copy and paste job, none of the 
changes originated with me. Therefore, I have no copyright claim.
In any case, I made no changes to the license since forking the
original repo. So even if copyright assignment to me could be
implied for these changes, which I don't think it can, since I have
published them publicly under the same MIT License those 
changes would still be freely useable under the terms of that
license. In short, I don't think that this pull request should present
any licensing issues.
